### PR TITLE
Add different units

### DIFF
--- a/Waterminder/Waterminder WatchKit Extension/Assets.xcassets/Complication.complicationset/Contents.json
+++ b/Waterminder/Waterminder WatchKit Extension/Assets.xcassets/Complication.complicationset/Contents.json
@@ -1,48 +1,53 @@
 {
   "assets" : [
     {
-      "idiom" : "watch",
       "filename" : "Circular.imageset",
+      "idiom" : "watch",
       "role" : "circular"
     },
     {
-      "idiom" : "watch",
       "filename" : "Extra Large.imageset",
+      "idiom" : "watch",
       "role" : "extra-large"
     },
     {
-      "idiom" : "watch",
       "filename" : "Graphic Bezel.imageset",
+      "idiom" : "watch",
       "role" : "graphic-bezel"
     },
     {
-      "idiom" : "watch",
       "filename" : "Graphic Circular.imageset",
+      "idiom" : "watch",
       "role" : "graphic-circular"
     },
     {
-      "idiom" : "watch",
       "filename" : "Graphic Corner.imageset",
+      "idiom" : "watch",
       "role" : "graphic-corner"
     },
     {
+      "filename" : "Graphic Extra Large.imageset",
       "idiom" : "watch",
+      "role" : "graphic-extra-large"
+    },
+    {
       "filename" : "Graphic Large Rectangular.imageset",
+      "idiom" : "watch",
       "role" : "graphic-large-rectangular"
     },
     {
-      "idiom" : "watch",
       "filename" : "Modular.imageset",
+      "idiom" : "watch",
       "role" : "modular"
     },
     {
-      "idiom" : "watch",
       "filename" : "Utilitarian.imageset",
+      "idiom" : "watch",
       "role" : "utilitarian"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Waterminder/Waterminder WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Extra Large.imageset/Contents.json
+++ b/Waterminder/Waterminder WatchKit Extension/Assets.xcassets/Complication.complicationset/Graphic Extra Large.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Waterminder/Waterminder WatchKit Extension/Constants.swift
+++ b/Waterminder/Waterminder WatchKit Extension/Constants.swift
@@ -11,4 +11,5 @@ import Foundation
 enum UserDefaultsConstant {
     static let firstUserInteraction = "firstUserInteraction"
     static let waterTarget = "waterTarget"
+    static let chosenUnit = "chosenUnit"
 }

--- a/Waterminder/Waterminder WatchKit Extension/Extensions/Double+Extensions.swift
+++ b/Waterminder/Waterminder WatchKit Extension/Extensions/Double+Extensions.swift
@@ -2,6 +2,11 @@ import Foundation
 
 extension Double {
     func toMilliliters() -> String {
-        "\(Int(self).description)ml"
+        Measurement(value: self, unit: UnitVolume.milliliters).string
+    }
+
+    func toOunces() -> String {
+        Measurement(value: self, unit: UnitVolume.milliliters)
+            .converted(to: .fluidOunces).string
     }
 }

--- a/Waterminder/Waterminder WatchKit Extension/Extensions/Measurement+Extensions.swift
+++ b/Waterminder/Waterminder WatchKit Extension/Extensions/Measurement+Extensions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Measurement where UnitType: UnitVolume {
+    var string: String {
+        MeasurementFormatter.volumeFormatter.string(from: self)
+    }
+}

--- a/Waterminder/Waterminder WatchKit Extension/Extensions/MeasurementFormatter+Extensions.swift
+++ b/Waterminder/Waterminder WatchKit Extension/Extensions/MeasurementFormatter+Extensions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension MeasurementFormatter {
+    static let volumeFormatter: MeasurementFormatter = {
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .providedUnit
+        formatter.unitStyle = .medium
+        formatter.numberFormatter.maximumFractionDigits = 1
+        return formatter
+    }()
+}

--- a/Waterminder/Waterminder WatchKit Extension/Screens/MenuView.swift
+++ b/Waterminder/Waterminder WatchKit Extension/Screens/MenuView.swift
@@ -19,16 +19,16 @@ struct MenuView: View {
                     .onTapGesture {
                         selectedUnit = selectedUnit == .milliliters ? .fluidOunces : .milliliters
                     }
-                    .background(
-                        RoundedRectangle(cornerRadius: 25.0)
-                            .padding(EdgeInsets(top: -2, leading: -8, bottom: -2, trailing: -8))
-                            .foregroundColor(.gray.opacity(isMilliliters ? 0.2 : 0))
-                    )
                 Image(systemName: "checkmark.circle.fill")
                     .resizable()
                     .frame(width: 20, height: 20)
                     .opacity(isMilliliters ? 1 : 0)
             }
+            .background(
+                RoundedRectangle(cornerRadius: 25.0)
+                    .padding(EdgeInsets(top: -2, leading: -8, bottom: -2, trailing: -8))
+                    .foregroundColor(.gray.opacity(isMilliliters ? 0.2 : 0))
+            )
             Spacer()
             HStack(spacing: 16) {
                 Text(target.toOunces())
@@ -37,16 +37,16 @@ struct MenuView: View {
                     .onTapGesture {
                         selectedUnit = isMilliliters ? .fluidOunces : .milliliters
                     }
-                    .background(
-                        RoundedRectangle(cornerRadius: 25.0)
-                            .padding(EdgeInsets(top: -2, leading: -8, bottom: -2, trailing: -8))
-                            .foregroundColor(.gray.opacity(isMilliliters ? 0 : 0.2))
-                    )
                 Image(systemName: "checkmark.circle.fill")
                     .resizable()
                     .frame(width: 20, height: 20)
                     .opacity(isMilliliters ? 0 : 1)
             }
+            .background(
+                RoundedRectangle(cornerRadius: 25.0)
+                    .padding(EdgeInsets(top: -2, leading: -8, bottom: -2, trailing: -8))
+                    .foregroundColor(.gray.opacity(isMilliliters ? 0 : 0.2))
+            )
             Spacer()
             Button(action: {
                 self.newSelections(self.target, self.selectedUnit)

--- a/Waterminder/Waterminder WatchKit Extension/Screens/MenuView.swift
+++ b/Waterminder/Waterminder WatchKit Extension/Screens/MenuView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 struct MenuView: View {
     @State var target: Double
-    var newTargetSelected: (Double) -> Void
+    @State var selectedUnit: UnitVolume
+    var newSelections: (_ target: Double, _ unit: UnitVolume) -> Void
     var body: some View {
         VStack {
             Text("Select the target")
@@ -11,9 +12,29 @@ struct MenuView: View {
             Text(target.toMilliliters())
                 .font(.system(size: 24, weight: .semibold, design: .rounded))
                 .foregroundColor(.init(red: 0, green: 0.8, blue: 1))
+                .onTapGesture {
+                    selectedUnit = selectedUnit == .milliliters ? .fluidOunces : .milliliters
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 25.0)
+                        .padding(EdgeInsets(top: -2, leading: -8, bottom: -2, trailing: -8))
+                        .foregroundColor(.gray.opacity(selectedUnit == .milliliters ? 0.5 : 0))
+                )
+            Spacer()
+            Text(target.toOunces())
+                .font(.system(size: 24, weight: .semibold, design: .rounded))
+                .foregroundColor(.init(red: 0, green: 0.8, blue: 1))
+                .onTapGesture {
+                    selectedUnit = selectedUnit == .milliliters ? .fluidOunces : .milliliters
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 25.0)
+                        .padding(EdgeInsets(top: -2, leading: -8, bottom: -2, trailing: -8))
+                        .foregroundColor(.gray.opacity(selectedUnit == .fluidOunces ? 0.5 : 0))
+                )
             Spacer()
             Button(action: {
-                self.newTargetSelected(self.target)
+                self.newSelections(self.target, self.selectedUnit)
             }) {
                 Text("Save")
             }
@@ -26,7 +47,7 @@ struct MenuView: View {
     
 struct MenuView_Previews: PreviewProvider {
     static var previews: some View {
-        MenuView(target: 2000) { target in
+        MenuView(target: 2000, selectedUnit: .milliliters) { target, unit in
             print(target)
         }
     }

--- a/Waterminder/Waterminder WatchKit Extension/Screens/MenuView.swift
+++ b/Waterminder/Waterminder WatchKit Extension/Screens/MenuView.swift
@@ -4,34 +4,49 @@ struct MenuView: View {
     @State var target: Double
     @State var selectedUnit: UnitVolume
     var newSelections: (_ target: Double, _ unit: UnitVolume) -> Void
+    var isMilliliters: Bool {
+        selectedUnit == .milliliters
+    }
     var body: some View {
         VStack {
             Text("Select the target")
                 .font(.system(.headline, design: .rounded))
             Spacer()
-            Text(target.toMilliliters())
-                .font(.system(size: 24, weight: .semibold, design: .rounded))
-                .foregroundColor(.init(red: 0, green: 0.8, blue: 1))
-                .onTapGesture {
-                    selectedUnit = selectedUnit == .milliliters ? .fluidOunces : .milliliters
-                }
-                .background(
-                    RoundedRectangle(cornerRadius: 25.0)
-                        .padding(EdgeInsets(top: -2, leading: -8, bottom: -2, trailing: -8))
-                        .foregroundColor(.gray.opacity(selectedUnit == .milliliters ? 0.5 : 0))
-                )
+            HStack(spacing: 16) {
+                Text(target.toMilliliters())
+                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                    .foregroundColor(.init(red: 0, green: 0.8, blue: 1))
+                    .onTapGesture {
+                        selectedUnit = selectedUnit == .milliliters ? .fluidOunces : .milliliters
+                    }
+                    .background(
+                        RoundedRectangle(cornerRadius: 25.0)
+                            .padding(EdgeInsets(top: -2, leading: -8, bottom: -2, trailing: -8))
+                            .foregroundColor(.gray.opacity(isMilliliters ? 0.2 : 0))
+                    )
+                Image(systemName: "checkmark.circle.fill")
+                    .resizable()
+                    .frame(width: 20, height: 20)
+                    .opacity(isMilliliters ? 1 : 0)
+            }
             Spacer()
-            Text(target.toOunces())
-                .font(.system(size: 24, weight: .semibold, design: .rounded))
-                .foregroundColor(.init(red: 0, green: 0.8, blue: 1))
-                .onTapGesture {
-                    selectedUnit = selectedUnit == .milliliters ? .fluidOunces : .milliliters
-                }
-                .background(
-                    RoundedRectangle(cornerRadius: 25.0)
-                        .padding(EdgeInsets(top: -2, leading: -8, bottom: -2, trailing: -8))
-                        .foregroundColor(.gray.opacity(selectedUnit == .fluidOunces ? 0.5 : 0))
-                )
+            HStack(spacing: 16) {
+                Text(target.toOunces())
+                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                    .foregroundColor(.init(red: 0, green: 0.8, blue: 1))
+                    .onTapGesture {
+                        selectedUnit = isMilliliters ? .fluidOunces : .milliliters
+                    }
+                    .background(
+                        RoundedRectangle(cornerRadius: 25.0)
+                            .padding(EdgeInsets(top: -2, leading: -8, bottom: -2, trailing: -8))
+                            .foregroundColor(.gray.opacity(isMilliliters ? 0 : 0.2))
+                    )
+                Image(systemName: "checkmark.circle.fill")
+                    .resizable()
+                    .frame(width: 20, height: 20)
+                    .opacity(isMilliliters ? 0 : 1)
+            }
             Spacer()
             Button(action: {
                 self.newSelections(self.target, self.selectedUnit)

--- a/Waterminder/Waterminder WatchKit Extension/Screens/WaterView.swift
+++ b/Waterminder/Waterminder WatchKit Extension/Screens/WaterView.swift
@@ -33,9 +33,10 @@ extension WaterView {
     }
     
     func menu() -> some View {
-        MenuView(target: viewModel.drinkingTarget) { newTarget in
+        MenuView(target: viewModel.drinkingTarget, selectedUnit: viewModel.chosenUnit) { newTarget, newUnit in
             self.viewModel.didTapReset()
             self.viewModel.updateTarget(newTarget: newTarget)
+            self.viewModel.updateUnit(newUnit: newUnit)
             self.isShowingMenu.toggle()
         }
     }

--- a/Waterminder/Waterminder WatchKit Extension/Screens/WaterViewModel.swift
+++ b/Waterminder/Waterminder WatchKit Extension/Screens/WaterViewModel.swift
@@ -5,6 +5,9 @@ class WaterViewModel: ObservableObject {
     @Published
     var drinkingAmount: Double = 100.0
     var waterLevel: CGFloat = .zero
+    var isMilliliters: Bool {
+        chosenUnit == .milliliters
+    }
     var isFirstUserInteraction: Bool {
         if let status = UserDefaults.standard.value(forKey: UserDefaultsConstant.firstUserInteraction) as? Bool {
             return status
@@ -18,15 +21,22 @@ class WaterViewModel: ObservableObject {
         }
         return target
     }()
+    var chosenUnit: UnitVolume = {
+        guard let unit = UserDefaults.standard.string(forKey: UserDefaultsConstant.chosenUnit) else {
+            return .milliliters
+        }
+        return unit == UnitVolume.milliliters.symbol ? .milliliters : .fluidOunces
+    }()
     
     var isGoalReached: Bool {
         round(drinkingTarget) == .zero
     }
     
     var targetText: String {
-        isGoalReached
+        let targetString = isMilliliters ? drinkingTarget.toMilliliters() : drinkingTarget.toOunces()
+        return isGoalReached
             ? "💦 Nice job! 💦"
-            : "Target: \(drinkingTarget.toMilliliters())"
+            : "Target: \(targetString)"
     }
     
     var minimumInterval: Double {
@@ -34,7 +44,7 @@ class WaterViewModel: ObservableObject {
     }
     
     var drinkText: String {
-        drinkingAmount.toMilliliters()
+        isMilliliters ? drinkingAmount.toMilliliters() : drinkingAmount.toOunces()
     }
     
     func didTapDrink() {
@@ -57,6 +67,11 @@ class WaterViewModel: ObservableObject {
     func updateTarget(newTarget: Double) {
         drinkingTarget = newTarget
         UserDefaults.standard.setValue(drinkingTarget, forKey: UserDefaultsConstant.waterTarget)
+    }
+
+    func updateUnit(newUnit: UnitVolume) {
+        chosenUnit = newUnit
+        UserDefaults.standard.setValue(chosenUnit.symbol, forKey: UserDefaultsConstant.chosenUnit)
     }
     
     func didTapReset() {

--- a/Waterminder/Waterminder.xcodeproj/project.pbxproj
+++ b/Waterminder/Waterminder.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		8B92935925D2244F0053891D /* HealthKitSetupAssistant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B92935825D2244F0053891D /* HealthKitSetupAssistant.swift */; };
 		8B92936025D224820053891D /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B92935F25D224820053891D /* HealthKit.framework */; };
 		8BEF5A2425D3009E00BF440C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEF5A2325D3009E00BF440C /* Constants.swift */; };
+		CE092C1A2711EA420069F5DE /* Measurement+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE092C182711EA420069F5DE /* Measurement+Extensions.swift */; };
+		CE092C1B2711EA420069F5DE /* MeasurementFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE092C192711EA420069F5DE /* MeasurementFormatter+Extensions.swift */; };
 		EB33776923341E77000D8850 /* Waterminder WatchKit App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = EB33776823341E77000D8850 /* Waterminder WatchKit App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		EB33776F23341E77000D8850 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EB33776D23341E77000D8850 /* Interface.storyboard */; };
 		EB33777123341E7B000D8850 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EB33777023341E7B000D8850 /* Assets.xcassets */; };
@@ -77,6 +79,8 @@
 		8B92935F25D224820053891D /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS7.2.sdk/System/Library/Frameworks/HealthKit.framework; sourceTree = DEVELOPER_DIR; };
 		8B92936425D2249A0053891D /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8BEF5A2325D3009E00BF440C /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		CE092C182711EA420069F5DE /* Measurement+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Measurement+Extensions.swift"; sourceTree = "<group>"; };
+		CE092C192711EA420069F5DE /* MeasurementFormatter+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MeasurementFormatter+Extensions.swift"; sourceTree = "<group>"; };
 		EB33776423341E77000D8850 /* Waterminder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Waterminder.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB33776823341E77000D8850 /* Waterminder WatchKit App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Waterminder WatchKit App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB33776E23341E77000D8850 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
@@ -192,6 +196,8 @@
 			isa = PBXGroup;
 			children = (
 				EB42D95F2334547300EBB5C8 /* Double+Extensions.swift */,
+				CE092C182711EA420069F5DE /* Measurement+Extensions.swift */,
+				CE092C192711EA420069F5DE /* MeasurementFormatter+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -342,8 +348,10 @@
 				EB42D96323345A1F00EBB5C8 /* MenuView.swift in Sources */,
 				EB33777D23341E7B000D8850 /* WaterView.swift in Sources */,
 				8BEF5A2425D3009E00BF440C /* Constants.swift in Sources */,
+				CE092C1B2711EA420069F5DE /* MeasurementFormatter+Extensions.swift in Sources */,
 				EB33778323341E7B000D8850 /* NotificationController.swift in Sources */,
 				EB33778123341E7B000D8850 /* ExtensionDelegate.swift in Sources */,
+				CE092C1A2711EA420069F5DE /* Measurement+Extensions.swift in Sources */,
 				8B92935925D2244F0053891D /* HealthKitSetupAssistant.swift in Sources */,
 				EB42D9652335306F00EBB5C8 /* WaterViewModel.swift in Sources */,
 				EB33778523341E7B000D8850 /* NotificationView.swift in Sources */,


### PR DESCRIPTION
This MR adds a unit setting to the setup menu to solve https://github.com/caiobzen/water-reminder-swiftui/issues/3

![grafik](https://user-images.githubusercontent.com/35889530/136668319-6ffaebf1-95e0-4471-b7a1-9f67ceb68a39.png) ![grafik](https://user-images.githubusercontent.com/35889530/136667767-18b8f1cb-8c04-4710-bcfe-eff42f0d1cff.png)

![grafik](https://user-images.githubusercontent.com/35889530/136668335-a71d9321-aacc-41df-bea4-0aec67dfc20e.png) ![grafik](https://user-images.githubusercontent.com/35889530/136667736-6aa96519-131d-4c45-b49c-61ab8d34131d.png)


Users can tap on the value in ml or fl oz to use this value throughout the app.

I added `Measurement` and `MeasurementFormatter` to make conversion easier and automatically localized.